### PR TITLE
Create codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+ignore:
+  - "docs/"
+  - "inst/"
+  - "man/"
+  - "src/"
+  - "tools/"
+
+comment: false


### PR DESCRIPTION
I created a configuration file for [codecov][codecov] to ignore non-code files and to stop commenting its output. With the config, files in `docs/`, `inst/`, `man/`, `src/`, `tools` will not be tested for code coverage anymore.

Sadly, stan is not supported by Codecov ([ref](https://docs.codecov.io/docs)), so only the R codes in `R/` will be tested from now on.

[codecov]: https://codecov.io/gh/CCS-Lab/hBayesDM