### PR TITLE
Update .Rbuildignore to ignore hidden files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,5 +2,7 @@
 ^\.Rproj\.user$
 ^.*\.o$
 ^\cleanup*
-README.Rmd
-
+^*.Rmd
+^\.editorconfig
+^\.travis\.yml
+^\.gitignore


### PR DESCRIPTION
On the output log of Travis CI, there is an error due to the existence of hidden files.

```
checking whether package ‘hBayesDM’ can be installed ... ERROR
Installation failed.
See ‘/home/travis/build/CCS-Lab/hBayesDM/hBayesDM.Rcheck/00install.out’ for details.checking for hidden files and directories ... NOTE
Found the following hidden files and directories:
  .editorconfig
  .travis.yml
These were most likely included in error. See section ‘Package
structure’ in the ‘Writing R Extensions’ manual.
```

Since the [R package structure][r-package-structure] requires no hidden file included, I added the patterns of hidden files to `.Rbuildignore`.

[r-package-structure]: https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Package-structure