### PR TITLE
Fixed .Rbuildignore with proper regex syntax

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,7 +2,7 @@
 ^\.Rproj\.user$
 ^.*\.o$
 ^\cleanup*
-^*.Rmd
+^.*\.Rmd
 ^\.editorconfig
 ^\.travis\.yml
 ^\.gitignore


### PR DESCRIPTION
I thought the glob pattern was used for `.Rbuildignore`, but regex patterns are used in the file. So I changed it to use proper regex pattern.