### PR TITLE
Set the wait time limit to 30 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ apt_packages:
   - libcurl4-openssl-dev
   - libxml2-dev
 
-install:
-  - R -e 'devtools::install_deps(dep = T)'
-
 script:
   - travis_wait 30 R CMD build .
   - travis_wait 30 R CHECK *tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,15 @@ os:
 
 # System dependencies for HTTP calling
 apt_packages:
- - libcurl4-openssl-dev
- - libxml2-dev
+  - libcurl4-openssl-dev
+  - libxml2-dev
+
+install:
+  - R -e 'devtools::install_deps(dep = T)'
+
+script:
+  - travis_wait 30 R CMD build .
+  - travis_wait 30 R CHECK *tar.gz
 
 r_binary_packages:
  - testthat


### PR DESCRIPTION
The latest build on Travis showed the following outputs:

```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

The build has been terminated
```

Not to terminate during the long compilation time, I increased the wait time limit to 30 minutes.

**Note**: Since this PR is to make the build on Travis CI success, please merge this PR after the corresponding build is successfully done.