### PR TITLE
Check for common files in R/Python packages to match via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ cache:
 
 matrix:
   include:
+    - name: Test sync (R/Python packages)
+      script:
+        - diff -r Python/hbayesdm/common/extdata R/inst/extdata
+        - diff -r Python/hbayesdm/common/stan_files R/inst/stan_files
     - name: Ubuntu + g++-7
       os: linux
       dist: trusty
@@ -134,10 +138,6 @@ matrix:
         - sudo -H pipenv run pylint hbayesdm --rcfile=setup.cfg --exit-zero
         - sudo -H pipenv run travis-sphinx build
         - sudo -H pipenv run travis-sphinx deploy
-    - name: Test sync (R/Python packages)
-      script:
-        - diff -r Python/hbayesdm/common/extdata R/inst/extdata
-        - diff -r Python/hbayesdm/common/stan_files R/inst/stan_files
 
 # r_github_packages:
 #   - r-lib/covr

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,10 @@ matrix:
         - sudo -H pipenv run pylint hbayesdm --rcfile=setup.cfg --exit-zero
         - sudo -H pipenv run travis-sphinx build
         - sudo -H pipenv run travis-sphinx deploy
+    - name: Test sync (R/Python packages)
+      script:
+        - diff -r Python/hbayesdm/common/extdata R/inst/extdata
+        - diff -r Python/hbayesdm/common/stan_files R/inst/stan_files
 
 # r_github_packages:
 #   - r-lib/covr


### PR DESCRIPTION
Use Travis CI to check for `stan_files/` and `extdata/` directories to sync between the two R/Python packages.

```sh
diff -r Python/hbayesdm/common/extdata R/inst/extdata
diff -r Python/hbayesdm/common/stan_files R/inst/stan_files
```