### PR TITLE
Fix preprocess_func for `choiceRT_ddm`

### DIFF
--- a/Python/hbayesdm/preprocess_funcs.py
+++ b/Python/hbayesdm/preprocess_funcs.py
@@ -170,8 +170,10 @@ def choiceRT_preprocess_func(self, raw_data, general_info, additional_args):
     subj_group = iter(general_info['grouped_data'])
     for s in range(n_subj):
         _, subj_data = next(subj_group)
-        RTu[s][:Nu[s]] = subj_data['rt'][subj_data['choice'] == 2]
-        RTl[s][:Nl[s]] = subj_data['rt'][subj_data['choice'] == 1]
+        if Nu[s] > 0:
+            RTu[s][:Nu[s]] = subj_data['rt'][subj_data['choice'] == 2]
+        if Nl[s] > 0:
+            RTl[s][:Nl[s]] = subj_data['rt'][subj_data['choice'] == 1]
 
     # Minimum reaction time
     minRT = np.full(n_subj, -1, dtype=float)

--- a/R/R/preprocess_funcs.R
+++ b/R/R/preprocess_funcs.R
@@ -161,8 +161,10 @@ choiceRT_preprocess_func <- function(raw_data, general_info, RTbound = 0.1) {
     subj <- subjs[i]
     subj_data <- subset(raw_data, raw_data$subjid == subj)
 
-    RTu[i, 1:Nu[i]] <- subj_data$rt[subj_data$choice == 2]  # (Nu/Nl[i]+1):Nu/Nl_max will be padded with 0's
-    RTl[i, 1:Nl[i]] <- subj_data$rt[subj_data$choice == 1]  # 0 padding is skipped in likelihood calculation
+    if (Nu[i] > 0)
+      RTu[i, 1:Nu[i]] <- subj_data$rt[subj_data$choice == 2]  # (Nu/Nl[i]+1):Nu/Nl_max will be padded with 0's
+    if (Nl[i] > 0)
+      RTl[i, 1:Nl[i]] <- subj_data$rt[subj_data$choice == 1]  # 0 padding is skipped in likelihood calculation
   }
 
   # Minimum reaction time


### PR DESCRIPTION
Related with #95.

In `choiceRT_preprocess_func`, this PR fixed an error if there is no trial choosing one option when assigning RT values.

```
Error in RTu[i, 1:Nu[i]] <- subj_data$rt[subj_data$choice == 2] : 
  replacement has length zero
```