### PR TITLE
Issue 140: Convert cache_file string to use string for os.getuid

### DIFF
--- a/Python/hbayesdm/base.py
+++ b/Python/hbayesdm/base.py
@@ -645,10 +645,10 @@ class TaskModel(metaclass=ABCMeta):
         if getattr(os, 'getuid', None) is None:
             uid = 'windows'
         else:
-            uid = os.getuid()
+            uid = str(os.getuid())
 
         cache_file = tempdir / (
-            'cached-hBayesDM_model-%s-pystan_%s_user-%d.pkl' %
+            'cached-hBayesDM_model-%s-pystan_%s_user-%s.pkl' %
             (model, _pystan_version, uid)
         )
 


### PR DESCRIPTION
When using the develop branch which included the fix for https://github.com/CCS-Lab/hBayesDM/issues/140, I ran into the following error:
![image](https://user-images.githubusercontent.com/72350768/199637405-adbee759-33df-4323-9a35-4485b5600eb2.png)

This change should ensure that in both cases we use a string for the cache_file name.

Let me know your thoughts, ty!