### PR TITLE
Fix input checking

### DIFF
--- a/R/R/hBayesDM_model.R
+++ b/R/R/hBayesDM_model.R
@@ -141,17 +141,11 @@ hBayesDM_model <- function(task_name,
       stop("** Posterior predictions are not yet available for this model. **\n")
     }
 
-    if (is.null(data) || is.na(data) || data == "") {
-      stop("Invalid input for the 'data' value. ",
-           "You should pass a data.frame, or a filepath for a data file,",
-           "\"example\" for an example dataset, ",
-           "or \"choose\" to choose it in a prompt.")
-
-    } else if ("data.frame" %in% class(data)) {
+    if (is.data.frame(data)) {
       # Use the given data object
       raw_data <- data.table::as.data.table(data)
 
-    } else if ("character" %in% class(data)) {
+    } else if (length(data) == 1 && is.character(data)) {
       # Set
       if (data == "example") {
         example_data <-
@@ -183,7 +177,7 @@ hBayesDM_model <- function(task_name,
 
     } else {
       stop("Invalid input for the 'data' value. ",
-           "You should pass a data.frame, or a filepath for a data file,",
+           "You should pass a data.frame, or a filepath for a TSV file,",
            "\"example\" for an example dataset, ",
            "or \"choose\" to choose it in a prompt.")
     }
@@ -485,7 +479,7 @@ hBayesDM_model <- function(task_name,
                              thin    = nthin,
                              control = list(adapt_delta   = adapt_delta,
                                             stepsize      = stepsize,
-                                            max_treedepth = max_treedepth))                             
+                                            max_treedepth = max_treedepth))
     }
 
     # Extract from the Stan fit object


### PR DESCRIPTION
Addressing #153. Input checking in [hBayesDM/R/R/hBayesDM_model.R](https://github.com/CCS-Lab/hBayesDM/blob/534907d9cbe7101b3109feeec808cdbd380a93f2/R/R/hBayesDM_model.R#L144) is broken, with the function failing for `R >= 4.2`. The check in the offending line did not make a whole lot of sense to begin with: It tested for element-wise `NA` and empty strings, while `if` requires a scalar input. Furthermore, the following `else if`s do enough input checking: if none of them matches, the final `else` will essentially fail in the same way that the first `if` tested for. 

PS: I am not a fan of a modeling function taking a user-provided path and importing data from a TSV file. TSV is not a well-defined format as can be seem with the number of options that the import function takes. And I don't see where the documentation the user is told how the TSV should be structured. This is just asking for user error. The user should do the import themselves, check if it is properly imported and then pass it to the modeling function. But that is not something I am addressing in this PR.

