### PR TITLE
Setup task-agnostic model configuration

### DIFF
--- a/R/R/hBayesDM_model.R
+++ b/R/R/hBayesDM_model.R
@@ -151,6 +151,8 @@ hBayesDM_model <- function(task_name = "",
         model_meta <- c()
         if (task_name != "") {
           model_meta <- c(model_meta, task_name)
+        } else {
+          model_meta <- c(model_meta, model_name)
         }
         if (model_type != "") {
           model_meta <- c(model_meta, model_type)

--- a/R/R/hBayesDM_model.R
+++ b/R/R/hBayesDM_model.R
@@ -102,7 +102,7 @@
 #'
 #' @return A specific hBayesDM model function.
 
-hBayesDM_model <- function(task_name,
+hBayesDM_model <- function(task_name = "",
                            model_name,
                            model_type = "",
                            data_columns,
@@ -148,10 +148,18 @@ hBayesDM_model <- function(task_name,
     } else if (length(data) == 1 && is.character(data)) {
       # Set
       if (data == "example") {
-        example_data <-
-          ifelse(model_type == "",
-                 paste0(task_name, "_", "exampleData.txt"),
-                 paste0(task_name, "_", model_type, "_", "exampleData.txt"))
+        model_meta <- c()
+        if (task_name != "") {
+          model_meta <- c(model_meta, task_name)
+        }
+        if (model_type != "") {
+          model_meta <- c(model_meta, model_type)
+        }
+        if (length(model_meta) == 0) {
+          stop("invalid model configuration")
+        }
+        example_data <- paste0(paste(model_meta, collapse = "_"), "_exampleData.txt")
+
         datafile <- system.file("extdata", example_data, package = "hBayesDM")
 
         if (!file.exists(datafile)) {
@@ -282,11 +290,20 @@ hBayesDM_model <- function(task_name,
     }
 
     # Full name of model
-    if (model_type == "") {
-      model <- paste0(task_name, "_", model_name)
-    } else {
-      model <- paste0(task_name, "_", model_name, "_", model_type)
+    model_meta <- c()
+    if (task_name != "") {
+      model_meta <- c(model_meta, task_name)
     }
+    if (model_name != "") {
+      model_meta <- c(model_meta, model_name)
+    }
+    if (model_type != "") {
+      model_meta <- c(model_meta, model_type)
+    }
+    if (length(model_meta) == 0) {
+      stop("invalid model configuration")
+    }
+    model <- paste(model_meta, collapse = "_")
 
     # Set number of cores for parallel computing
     if (ncore <= 1) {

--- a/commons/convert-to-r.py
+++ b/commons/convert-to-r.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from yaml import Dumper, Loader
 
+from utils import model_info, preprocess_func_prefix
 
 def represent_none(self, _):
     return self.represent_scalar('tag:yaml.org,2002:null', '')
@@ -114,11 +115,7 @@ def format_references_block(cites_formatted):
 
 
 def generate_docs(info):
-    # Model full name (Snake-case)
-    model_function = [info['task_name']['code'], info['model_name']['code']]
-    if info['model_type']['code']:
-        model_function.append(info['model_type']['code'])
-    model_function = '_'.join(model_function)
+    model_function, _, _, _ = model_info(info)
 
     # Citations
     if info['task_name'].get('cite'):
@@ -234,22 +231,8 @@ def generate_docs(info):
 
 
 def generate_code(info):
-    # Model full name (Snake-case)
-    model_function = [info['task_name']['code'], info['model_name']['code']]
-    if info['model_type']['code']:
-        model_function.append(info['model_type']['code'])
-    model_function = '_'.join(model_function)
-
-    # Prefix to preprocess_func
-    prefix_preprocess_func = info['task_name']['code']
-    if info['model_type']['code']:
-        prefix_preprocess_func += '_' + info['model_type']['code']
-    preprocess_func = prefix_preprocess_func + '_preprocess_func'
-
-    # Model type code
-    model_type_code = info['model_type'].get('code')
-    if model_type_code is None:
-        model_type_code = ''
+    model_function, _, _, model_type_code = model_info(info)
+    preprocess_func = preprocess_func_prefix(info) + "_preprocess_func"
 
     # Data columns
     data_columns = ', '.join([
@@ -309,11 +292,7 @@ def generate_code(info):
 
 
 def generate_test(info):
-    # Model full name (Snake-case)
-    model_function = [info['task_name']['code'], info['model_name']['code']]
-    if info['model_type']['code']:
-        model_function.append(info['model_type']['code'])
-    model_function = '_'.join(model_function)
+    model_function, _, _, _ = model_info(info)
 
     # Read template for model tests
     with open(TEMPLATE_TEST, 'r') as f:
@@ -340,12 +319,7 @@ def main(info_fn):
     test = generate_test(info)
     output = docs + code
 
-    # Model full name (Snake-case)
-    model_function = [info['task_name']['code'],
-                      info['model_name']['code']]
-    if info['model_type']['code']:
-        model_function.append(info['model_type']['code'])
-    model_function = '_'.join(model_function)
+    model_function, _, _, _ = model_info(info)
 
     # Make directories if not exist
     if not PATH_OUTPUT.exists():

--- a/commons/convert-to-r.py
+++ b/commons/convert-to-r.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from yaml import Dumper, Loader
 
-from utils import model_info, preprocess_func_prefix
+from utils import model_info, preprocess_func_prefix, extract_or_empty_string
 
 def represent_none(self, _):
     return self.represent_scalar('tag:yaml.org,2002:null', '')
@@ -207,13 +207,13 @@ def generate_docs(info):
 
     docs = docs_template % dict(
         model_function=model_function,
-        task_name=info['task_name']['desc'],
-        task_code=info['task_name']['code'],
+        task_name=extract_or_empty_string(info, 'task_name', 'desc'),
+        task_code=extract_or_empty_string(info, 'task_name', 'code'),
         task_parencite=task_parencite,
-        model_name=info['model_name']['desc'],
-        model_code=info['model_name']['code'],
+        model_name=extract_or_empty_string(info, 'model_name', 'desc'),
+        model_code=extract_or_empty_string(info, 'model_name', 'code'),
         model_parencite=model_parencite,
-        model_type=info['model_type']['desc'],
+        model_type=extract_or_empty_string(info, 'model_type', 'desc'),
         notes=notes,
         contributor=contributors,
         data_columns=data_columns,
@@ -278,8 +278,8 @@ def generate_code(info):
 
     code = code_template % dict(
         model_function=model_function,
-        task_code=info['task_name']['code'],
-        model_code=info['model_name']['code'],
+        task_code=extract_or_empty_string(info, 'task_name', 'code'),
+        model_code=extract_or_empty_string(info, 'model_name', 'code'),
         model_type=model_type_code,
         data_columns=data_columns,
         parameters=parameters,

--- a/commons/utils.py
+++ b/commons/utils.py
@@ -20,11 +20,14 @@ def model_info(info):
 # Prefix to preprocess_func
 def preprocess_func_prefix(info):
     task_name_code = info.get('task_name', {}).get('code')
+    model_name_code = info.get('model_name', {}).get('code')
     model_type_code = info.get('model_type', {}).get('code')
 
     preprocess_func_prefix = []
     if task_name_code:
         preprocess_func_prefix.append(task_name_code)
+    else:
+        preprocess_func_prefix.append(model_name_code)
     if model_type_code:
         preprocess_func_prefix.append(model_type_code)
     return '_'.join(preprocess_func_prefix)

--- a/commons/utils.py
+++ b/commons/utils.py
@@ -1,0 +1,30 @@
+def model_info(info):
+    task_name_code = info.get('task_name', {}).get('code')
+    model_name_code = info.get('model_name', {}).get('code')
+    model_type_code = info.get('model_type', {}).get('code')
+
+    # Model full name (Snake-case)
+    model_function = []
+    if task_name_code is not None and len(task_name_code) > 0:
+        model_function.append(task_name_code)
+    if model_name_code is not None and len(model_name_code) > 0:
+        model_function.append(model_name_code)
+    if model_type_code is not None and len(model_type_code) > 0:
+        model_function.append(model_type_code)
+    model_function = '_'.join(model_function)
+
+    if model_type_code is None:
+        model_type_code = ''
+    return model_function, task_name_code, model_name_code, model_type_code
+
+# Prefix to preprocess_func
+def preprocess_func_prefix(info):
+    task_name_code = info.get('task_name', {}).get('code')
+    model_type_code = info.get('model_type', {}).get('code')
+
+    preprocess_func_prefix = []
+    if task_name_code:
+        preprocess_func_prefix.append(task_name_code)
+    if model_type_code:
+        preprocess_func_prefix.append(model_type_code)
+    return '_'.join(preprocess_func_prefix)

--- a/commons/utils.py
+++ b/commons/utils.py
@@ -28,3 +28,6 @@ def preprocess_func_prefix(info):
     if model_type_code:
         preprocess_func_prefix.append(model_type_code)
     return '_'.join(preprocess_func_prefix)
+
+def extract_or_empty_string(info, key, subkey):
+    return info[key][subkey] if info[key][subkey] is not None else ""


### PR DESCRIPTION
Background: Currently, all the models must be task-specific. Therefore, `task_name` must be specified for all the models.

```
task_name:
  code: prl
  desc: Probabilistic Reversal Learning Task
  cite:
model_name:
  code: hgf
  ...
```

Implementation: This PR allows task-agnostic model configuration. For models that can be used for more than a specific task, we can leave the `task_name` block in the yml configuration empty.

```
task_name:
  code:
  desc:
  cite:
model_name:
  code: hgf
```