### PR TITLE
HGF and allIndPars issues

### DIFF
--- a/Python/hbayesdm/preprocess_funcs.py
+++ b/Python/hbayesdm/preprocess_funcs.py
@@ -554,7 +554,7 @@ def hgf_ibrb_preprocess_func(self, raw_data, general_info, additional_args):
         "L": additional_args.get('L'),
         "u": u,
         "y": y,
-        "input_first": additional_args.get('input_first'),
+        "input_first": 1 if additional_args.get('input_first') else 0,
 
         "mu0": additional_args.get('mu0'),
         "sigma0": additional_args.get('sigma0'),
@@ -596,7 +596,7 @@ def hgf_ibrb_single_preprocess_func(self, raw_data, general_info, additional_arg
         "L": additional_args.get('L'),
         "u": u,
         "y": y,
-        "input_first": additional_args.get('input_first'),
+        "input_first": 1 if additional_args.get('input_first') else 0,
 
         "mu0": additional_args.get('mu0'),
         "sigma0": additional_args.get('sigma0'),


### PR DESCRIPTION
### RStan allIndPars enhancement
Before: parameter names were not specified (just V1, V2, ...)
<img width="235" height="196" alt="Screenshot 2025-08-27 at 2 23 17 PM" src="https://github.com/user-attachments/assets/9e20865a-e747-44eb-b5e1-e7e702c9a984" />

After: parameter names specified for each column & added subjID column
<img width="301" height="195" alt="Screenshot 2025-08-27 at 2 24 20 PM" src="https://github.com/user-attachments/assets/d78acca2-9c3a-4722-91a4-07e08094d5e2" />

### HGF allIndPars format

Instead of averaging `omega[1]` and `omega[2]` as `omega` for each subject, separated each of them in both PyStan and RStan fitting results.

<img width="377" height="210" alt="Screenshot 2025-08-27 at 2 30 12 PM" src="https://github.com/user-attachments/assets/bfae2dec-320f-4b5d-80ba-4956e7015b22" />
<img width="371" height="221" alt="image" src="https://github.com/user-attachments/assets/a3f39fd7-5106-4d9c-b03b-0ac0ad797f25" />

### PyStan HGF bugs

Didn't have a chance to run the PyStan codes during development, so there were some bugs. Fixed them in this PR.
- set `inits` using `vb` results : make the code handle kappa[1], omega[1], etc
- `hgf_ibrb_preprocess_func` : handle `input_first` data type issue (bool to int)