### PR TITLE
Python: add tight_layout to base plot function

### DIFF
--- a/Python/hbayesdm/base.py
+++ b/Python/hbayesdm/base.py
@@ -627,6 +627,8 @@ class TaskModel(metaclass=ABCMeta):
         elif type == 'trace':
             az.plot_trace(self.idata, var_names=var_names, **kwargs)
 
+        plt.tight_layout()
+
         plt.show()
 
     def plot_ind(self,


### PR DESCRIPTION
This PR adds `plt.tight_layout()` before `plt.show()` in `base.plot`.

before
<img width="1210" height="374" alt="overlapped" src="https://github.com/user-attachments/assets/3eb4511b-8034-40e4-bf84-280a75729e43" />

after
<img width="1525" height="391" alt="fixed" src="https://github.com/user-attachments/assets/8ba9c20b-60c1-4e08-84c9-547366e84b5a" />
